### PR TITLE
update to RFC draft 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ generic output in the style of RFC 3597:
 $ python3 digestify.py -g zonnestelsel.tk.zone
 Wrote ZONEMD digest 9dd24e284e7af7141d09d50c6360b80a823e9d54 to zonnestelsel.tk.zone.zonemd
 $ grep TYPE zonnestelsel.tk.zone.zonemd
-zonnestelsel.tk 300 IN TYPE65317 \# 25 783acfdb019dd24e284e7af7141d09d50c6360b80a823e9d54
+zonnestelsel.tk 300 IN TYPE63 \# 25 24 783acfdb019dd24e284e7af7141d09d50c6360b80a823e9d54
 ```
 
 Validation involves using the "-c" flag to check the file(s):

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Prototype implementation of ZONEMD for the IETF 102 hackathon.
 This implementation provides code to generate or validate zone digests
 as described in this Internet draft:
 
-https://tools.ietf.org/html/draft-wessels-dns-zone-digest-02
+https://tools.ietf.org/html/draft-wessels-dns-zone-digest-06
 
 The basic idea is to make a digest - sort of like a checksum - of the
 contents of the zone and include that in the zone as a record.
@@ -16,16 +16,12 @@ the digest and a command-line program to exercise it.
 
 This is a Python 3 module. To use it you need Python 3 installed.
 
-It requires the **dnspython** and **pygost** modules. You can install
+It requires the **dnspython** module. You can install
 these from PyPI in the usual way with `pip`:
 
 ```
 $ pip install -r requirements.txt
 ```
-
-In principle the software can be run without GOST support, and so the
-**pygost** module is not strictly required. However since it's so easy
-to install I opted against updating the code to work without it.
 
 ## Running
 
@@ -49,7 +45,7 @@ zonnestelsel.tk.zone.zonemd:zonnestelsel.tk 300 IN ZONEMD 2017120219 1 9dd24e284
 You can specify an alternate algorithm with the "-a" flag:
 
 ```
-$ python3 digestify.py -a gost vanaheimr.cf.zone
+$ python3 digestify.py -a sha384 vanaheimr.cf.zone
 Wrote ZONEMD digest 71f03c16524686592b85e2ea732afef7685563c1e127e66da83212cc3a532eb6 to vanaheimr.cf.zone.zonemd
 $ grep ZONEMD vanaheimr.cf.zone.zonemd
 vanaheimr.cf 300 IN ZONEMD 2017122152 3 71f03c16524686592b85e2ea732afef7685563c1e127e66da83212cc3a532eb6
@@ -76,7 +72,7 @@ zonnestelsel.tk.zone.zonemd is has a valid digest
 Any error will be reported with some hopefully helpful information:
 
 ```
-$ python3 digestify.py -a sha256 zonnestelsel.tk.zone
+$ python3 digestify.py -a sha384 zonnestelsel.tk.zone
 Wrote ZONEMD digest ae0b88b5d9784ded8ed2e497791c71e8accb70ea3c708fdc73f34255da66cb69 to zonnestelsel.tk.zone.zonemd
 $ sed 's/ 2 / 9 /' zonnestelsel.tk.zone.zonemd > broken.zone.zonemd
 $ python3 digestify.py -c broken.zone.zonemd

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ a new file with ".zonemd" added:
 
 ```
 $ grep ZONEMD vanaheimr.cf.zone.zonemd zonnestelsel.tk.zone.zonemd
-vanaheimr.cf.zone.zonemd:vanaheimr.cf 300 IN ZONEMD 2017122152 1 3858b487874286ff34b47aa9190596bc3c9d29c4
-zonnestelsel.tk.zone.zonemd:zonnestelsel.tk 300 IN ZONEMD 2017120219 1 9dd24e284e7af7141d09d50c6360b80a823e9d54
+vanaheimr.cf.zone.zonemd:vanaheimr.cf 300 IN ZONEMD 2017122152 1 0 3858b487874286ff34b47aa9190596bc3c9d29c4
+zonnestelsel.tk.zone.zonemd:zonnestelsel.tk 300 IN ZONEMD 2017120219 1 0 9dd24e284e7af7141d09d50c6360b80a823e9d54
 ```
 
 You can specify an alternate algorithm with the "-a" flag:
@@ -48,7 +48,7 @@ You can specify an alternate algorithm with the "-a" flag:
 $ python3 digestify.py -a sha384 vanaheimr.cf.zone
 Wrote ZONEMD digest 71f03c16524686592b85e2ea732afef7685563c1e127e66da83212cc3a532eb6 to vanaheimr.cf.zone.zonemd
 $ grep ZONEMD vanaheimr.cf.zone.zonemd
-vanaheimr.cf 300 IN ZONEMD 2017122152 3 71f03c16524686592b85e2ea732afef7685563c1e127e66da83212cc3a532eb6
+vanaheimr.cf 300 IN ZONEMD 2017122152 1 0 71f03c16524686592b85e2ea732afef7685563c1e127e66da83212cc3a532eb6
 ```
 
 If you are planning on importing the zone file into a server that does

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ generic output in the style of RFC 3597:
 $ python3 digestify.py -g zonnestelsel.tk.zone
 Wrote ZONEMD digest 9dd24e284e7af7141d09d50c6360b80a823e9d54 to zonnestelsel.tk.zone.zonemd
 $ grep TYPE zonnestelsel.tk.zone.zonemd
-zonnestelsel.tk 300 IN TYPE63 \# 25 24 783acfdb019dd24e284e7af7141d09d50c6360b80a823e9d54
+zonnestelsel.tk 300 IN TYPE63 \# 26 783acfdb019dd24e284e7af7141d09d50c6360b80a823e9d54BlaBlaEtc
 ```
 
 Validation involves using the "-c" flag to check the file(s):

--- a/digestify.py
+++ b/digestify.py
@@ -26,9 +26,9 @@ def main():
     parser.add_argument('--check', '-c', action='store_true',
                         help="check ZONEMD in zone file")
     parser.add_argument('--algorithm', '-a',
-                        help="set algorithm to use (defaults to sha1)",
-                        choices=('sha1', 'sha256', 'gost', 'sha384'),
-                        default='sha1')
+                        help="set algorithm to use (defaults to sha384)",
+                        choices=('sha384'),
+                        default='sha384')
     parser.add_argument('--generic', '-g', action='store_true',
                         help=f"treat ZONEMD as an unknown type (RFC 3597)")
     parser.add_argument('--placeholder', '-p', action='store_true',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 dnspython
-pygost

--- a/zonemd.py
+++ b/zonemd.py
@@ -77,7 +77,7 @@ class ZONEMD(dns.rdata.Rdata):
                     binascii.b2a_hex(rdata).decode())
         else:
             digest_hex = binascii.b2a_hex(self.digest).decode()
-            text = (str(self.serial) + ' ' +
+            text = (str(self.serial) + ' 0 ' +
                     str(self.algorithm) + ' ' + digest_hex)
         return text
 

--- a/zonemd.py
+++ b/zonemd.py
@@ -77,8 +77,8 @@ class ZONEMD(dns.rdata.Rdata):
                     binascii.b2a_hex(rdata).decode())
         else:
             digest_hex = binascii.b2a_hex(self.digest).decode()
-            text = (str(self.serial) + ' 0 ' +
-                    str(self.algorithm) + ' ' + digest_hex)
+            text = (str(self.serial) + ' ' +
+                    str(self.algorithm) + ' 0 ' + digest_hex)
         return text
 
     # pylint: disable=too-many-arguments

--- a/zonemd.py
+++ b/zonemd.py
@@ -2,7 +2,7 @@
 The zonemd module adds support for the ZONEMD record, as documented
 in:
 
-  https://tools.ietf.org/html/draft-wessels-dns-zone-digest-02
+  https://tools.ietf.org/html/draft-wessels-dns-zone-digest-06
 
 The idea is to provide a zone digest, which is a record that basically
 creates a checksum of the zone file.
@@ -28,10 +28,9 @@ import dns.rdataclass
 import dns.rdataset
 import dns.rdatatype
 import dns.zone
-import pygost.gost341194
 
 # The RTYPE for ZONEMD (use private-use number for now).
-ZONEMD_RTYPE = 65317
+ZONEMD_RTYPE = 63
 
 # Flag to output ZONEMD as an unknown type.
 ZONEMD_AS_GENERIC = False
@@ -111,18 +110,12 @@ class ZoneDigestUnknownAlgorithm(Exception):
 
 # Utility dictionary with the empty digests for each algorithm
 _EMPTY_DIGEST_BY_ALGORITHM = {
-    # SHA1
-    1: b'\0' * 20,
-    # SHA256
-    2: b'\0' * 32,
-    # GOST R 34.11-94
-    3: b'\0' * 32,
     # SHA384
-    4: b'\0' * 48
+    1: b'\0' * 48
 }
 
 
-def add_zonemd(zone, zonemd_algorithm='sha1', zonemd_ttl=None):
+def add_zonemd(zone, zonemd_algorithm='sha384', zonemd_ttl=None):
     """
     Add a ZONEMD record to a zone. This also removes any existing
     ZONEMD records in the zone.
@@ -135,9 +128,8 @@ def add_zonemd(zone, zonemd_algorithm='sha1', zonemd_ttl=None):
 
     @var zone: The zone object to update.
     @type zone: dns.zone.Zone
-    @var zonemd_algorithm: The name of the algorithm to use, either "sha1",
-                          "sha256", "gost", or "sha384", or the number of
-                          the algorithm to use.
+    @var zonemd_algorithm: The name of the algorithm to use,
+                      "sha384", or the number of the algorithm to use.
     @type zonemd_algorithm: str
     @var zonemd_ttl: The TTL to use for the ZONEMD record, or None to
                      get this from the zone SOA.
@@ -147,14 +139,8 @@ def add_zonemd(zone, zonemd_algorithm='sha1', zonemd_ttl=None):
 
     Returns the placeholder ZONEMD record added, as a ZONEMD object.
     """
-    if zonemd_algorithm in ('sha1', 1):
+    if zonemd_algorithm in ('sha384', 1):
         algorithm = 1
-    elif zonemd_algorithm in ('sha256', 2):
-        algorithm = 2
-    elif zonemd_algorithm in ('gost', 3):
-        algorithm = 3
-    elif zonemd_algorithm in ('sha384', 4):
-        algorithm = 4
     else:
         msg = 'Unknown digest ' + zonemd_algorithm
         raise ZoneDigestUnknownAlgorithm(msg)
@@ -189,7 +175,7 @@ def add_zonemd(zone, zonemd_algorithm='sha1', zonemd_ttl=None):
     return placeholder_rdata
 
 
-def calculate_zonemd(zone, zonemd_algorithm='sha1'):
+def calculate_zonemd(zone, zonemd_algorithm='sha384'):
     """
     Calculate the digest of the zone.
 
@@ -197,21 +183,13 @@ def calculate_zonemd(zone, zonemd_algorithm='sha1'):
 
     @var zone: The zone object to digest.
     @type zone: dns.zone.Zone
-    @var zonemd_algorithm: The name of the algorithm to use, either "sha1",
-                          "sha256", "gost", or "sha384", or the number of
-                          the algorithm to use.
+    @var zonemd_algorithm: The name of the algorithm to use,
+                  "sha384", or the number of the algorithm to use.
     @type zonemd_algorithm: str
     @raises ZoneDigestUnknownAlgorithm: zonemd_algorithm is unknown
     @rtype: bytes
     """
-    if zonemd_algorithm in ('sha1', 1):
-        hashing = hashlib.sha1()
-    elif zonemd_algorithm in ('sha256', 2):
-        hashing = hashlib.sha256()
-    elif zonemd_algorithm in ('gost', 3):
-        # pylint: disable=no-member
-        hashing = pygost.gost341194.new()
-    elif zonemd_algorithm in ('sha384', 4):
+    if zonemd_algorithm in ('sha384', 1):
         hashing = hashlib.sha384()
 
     # Sort the names in the zone. This is needed for canonization.
@@ -250,7 +228,7 @@ def calculate_zonemd(zone, zonemd_algorithm='sha1'):
     return hashing.digest()
 
 
-def update_zonemd(zone, zonemd_algorithm='sha1'):
+def update_zonemd(zone, zonemd_algorithm='sha384'):
     """
     Calculate the digest of the zone and update the ZONEMD record's
     digest value with that.
@@ -263,8 +241,7 @@ def update_zonemd(zone, zonemd_algorithm='sha1'):
 
     @var zone: The zone object to update.
     @type zone: dns.zone.Zone
-    @var zonemd_algorithm: The name of the algorithm to use, either "sha1",
-                          "sha256", "gost", or "sha384".
+    @var zonemd_algorithm: The name of the algorithm to use, "sha384".
     @type zonemd_algorithm: str
     @rtype: dns.rdataset.Rdataset
     @raises ZoneDigestUnknownAlgorithm: zonemd_algorithm is unknown
@@ -326,3 +303,4 @@ def validate_zonemd(zone):
 
     # Everything matches, enjoy your zone.
     return True, ""
+  


### PR DESCRIPTION
Not sure where it started, but now in the #6 RFC draft the only algorithm is sha384.
My edits remove anything else - however doesn't (yet) change the code to remove it as an (only) option.
The option to use ghost is no longer, and so I removed also the requirement.
Further the RR type became assigned by IANA, so I changed it to TYPE63.

Another thing that was added is the "Reserved flag" I've added it initially wrong, but in a later commit corrected the position (after the algo flag / before the digest).

Please verify if this script comes to the same hashes as in the examples in the RFC draft #6 - which -at least at draft #7- should be correct.